### PR TITLE
Add static OGP image generation for blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tk1024.net",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/noto-sans-jp": "^5.2.9",
         "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^1.5.0",
         "gray-matter": "^4.0.3",
@@ -636,6 +637,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-jp": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-jp/-/noto-sans-jp-5.2.9.tgz",
+      "integrity": "sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prebuild": "rimraf .next"
   },
   "dependencies": {
+    "@fontsource/noto-sans-jp": "^5.2.9",
     "@tailwindcss/typography": "^0.5.19",
     "@vercel/analytics": "^1.5.0",
     "gray-matter": "^4.0.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,12 @@ export const metadata: Metadata = {
   },
   description: siteMetadata.defaultDescription,
   metadataBase: new URL(siteUrl),
+  openGraph: {
+    siteName: siteMetadata.siteName,
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/post/[slug]/opengraph-image.tsx
+++ b/src/app/post/[slug]/opengraph-image.tsx
@@ -1,0 +1,171 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { ImageResponse } from "next/og";
+import { getPostMetadata, getSinglePostMetadata } from "@/getPostMetadata";
+import { siteName } from "@/site";
+
+export const alt = siteName;
+export const contentType = "image/png";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const dynamic = "force-static";
+
+export function generateStaticParams() {
+  return getPostMetadata().map((post) => ({
+    slug: post.slug,
+  }));
+}
+
+const notoSansJpRegular = readFile(
+  path.join(
+    process.cwd(),
+    "node_modules",
+    "@fontsource",
+    "noto-sans-jp",
+    "files",
+    "noto-sans-jp-japanese-400-normal.woff",
+  ),
+);
+
+const notoSansJpBold = readFile(
+  path.join(
+    process.cwd(),
+    "node_modules",
+    "@fontsource",
+    "noto-sans-jp",
+    "files",
+    "noto-sans-jp-japanese-700-normal.woff",
+  ),
+);
+
+export default async function OpenGraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = getSinglePostMetadata(slug);
+  const [regularFontData, boldFontData] = await Promise.all([
+    notoSansJpRegular,
+    notoSansJpBold,
+  ]);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          width: "100%",
+          height: "100%",
+          padding: 44,
+          background:
+            "linear-gradient(135deg, #eef2ff 0%, #ffffff 48%, #e0e7ff 100%)",
+          color: "#1f2937",
+          fontFamily:
+            'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+            height: "100%",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            borderRadius: 32,
+            border: "3px solid #312e81",
+            backgroundColor: "rgba(255,255,255,0.9)",
+            boxShadow: "0 18px 48px rgba(49, 46, 129, 0.14)",
+            padding: "42px 48px",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              color: "#4338ca",
+              fontSize: 28,
+              fontWeight: 700,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                width: 16,
+                height: 16,
+                borderRadius: 9999,
+                backgroundColor: "#4338ca",
+              }}
+            />
+            {siteName}
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flex: 1,
+              alignItems: "center",
+              fontSize: 68,
+              lineHeight: 1.2,
+              fontWeight: 800,
+              letterSpacing: "-0.04em",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {post.frontMatter.title}
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              color: "#4b5563",
+              fontSize: 26,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                maxWidth: 860,
+              }}
+            >
+              {post.frontMatter.description}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                flexShrink: 0,
+                marginLeft: 24,
+                color: "#3730a3",
+                fontWeight: 700,
+              }}
+            >
+              /post/{slug}
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "Noto Sans JP",
+          data: regularFontData,
+          style: "normal",
+          weight: 400,
+        },
+        {
+          name: "Noto Sans JP",
+          data: boldFontData,
+          style: "normal",
+          weight: 700,
+        },
+      ],
+    },
+  );
+}

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -13,6 +13,8 @@ import remarkGfm from "remark-gfm";
 
 import type { Metadata } from 'next';
 import { use } from 'react';
+import { siteUrl } from "@/site";
+import { siteMetadata } from "@/seo";
 
 // Using temporary synchronous access mode for backward compatibility
 
@@ -23,6 +25,10 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const resolvedParams = await params;
   const postData = getSinglePostMetadata(resolvedParams.slug);
+  const imageUrl = new URL(
+    `/post/${resolvedParams.slug}/opengraph-image`,
+    siteUrl,
+  ).toString();
 
   const metadata: Metadata = {
     title: postData.frontMatter.title,
@@ -30,6 +36,31 @@ export async function generateMetadata({
       postData.frontMatter.description,
       postData.content,
     ),
+    openGraph: {
+      siteName: siteMetadata.siteName,
+      title: postData.frontMatter.title,
+      description: getPostDescription(
+        postData.frontMatter.description,
+        postData.content,
+      ),
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${postData.frontMatter.title} | ${siteMetadata.siteName}`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: postData.frontMatter.title,
+      description: getPostDescription(
+        postData.frontMatter.description,
+        postData.content,
+      ),
+      images: [imageUrl],
+    },
   };
 
   return metadata;

--- a/src/site.ts
+++ b/src/site.ts
@@ -1,2 +1,4 @@
+export const siteName = "tk1024.net";
+
 export const siteUrl =
   process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "https://tk1024.net";


### PR DESCRIPTION
## Summary
- add a generated Open Graph image route for each blog post
- use Noto Sans JP in `next/og` so Japanese text renders consistently
- wire post metadata to the generated OGP image and restore the shared site name to `tk1024.net`

## Testing
- npm run build