### PR TITLE
feat: 記事ナビゲーション・レイアウト改善

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,18 +31,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${inter.className}`}>
-        <div className="grid lg:grid-cols-[280px_1fr] md:grid-cols-1">
-          <div className="lg:min-h-screen bg-indigo-700">
-            <Header />
-          </div>
-          <div className="col-auto lg:p-10 p-4 w-full box-border overflow-x-auto">
-            {children}
-          </div>
-          <div className="lg:col-span-2">
-            <Footer />
-          </div>
-        </div>
+      <body className={`${inter.className} flex flex-col min-h-screen`}>
+        <Header />
+        <main className="flex-1 w-full max-w-4xl mx-auto px-4 lg:px-10 py-8">
+          {children}
+        </main>
+        <Footer />
         <Analytics />
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,8 +36,10 @@ export default function RootLayout({
           <div className="lg:min-h-screen bg-indigo-700">
             <Header />
           </div>
-          <div className="col-auto lg:p-10 p-4 w-full box-border overflow-x-auto flex flex-col min-h-screen">
-            <div className="flex-1">{children}</div>
+          <div className="col-auto lg:p-10 p-4 w-full box-border overflow-x-auto">
+            {children}
+          </div>
+          <div className="lg:col-span-2">
             <Footer />
           </div>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { Analytics } from "@vercel/analytics/react";
 import { siteUrl } from "@/site";
@@ -35,8 +36,9 @@ export default function RootLayout({
           <div className="lg:min-h-screen bg-indigo-700">
             <Header />
           </div>
-          <div className="col-auto lg:p-10 p-4 w-full box-border overflow-x-auto">
-            {children}
+          <div className="col-auto lg:p-10 p-4 w-full box-border overflow-x-auto flex flex-col min-h-screen">
+            <div className="flex-1">{children}</div>
+            <Footer />
           </div>
         </div>
         <Analytics />

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -134,6 +134,19 @@ export default function Page({
   const newerPost = currentIndex > 0 ? allPosts[currentIndex - 1] : null;
   const olderPost = currentIndex < allPosts.length - 1 ? allPosts[currentIndex + 1] : null;
 
+  const currentTags: string[] = frontMatter.tags ?? [];
+  const relatedPosts = currentTags.length > 0
+    ? allPosts
+        .filter((p) => p.slug !== resolvedParams.slug)
+        .map((p) => ({
+          ...p,
+          matchCount: (p.meta.tags ?? []).filter((t: string) => currentTags.includes(t)).length,
+        }))
+        .filter((p) => p.matchCount > 0)
+        .sort((a, b) => b.matchCount - a.matchCount)
+        .slice(0, 3)
+    : [];
+
   return (
     <div className="">
       <article>
@@ -204,6 +217,28 @@ export default function Page({
             )}
           </div>
         </nav>
+      )}
+
+      {relatedPosts.length > 0 && (
+        <section className="mt-10 pt-8 border-t border-gray-200">
+          <h2 className="text-sm font-bold text-gray-500 mb-4">関連記事</h2>
+          <div className="space-y-2">
+            {relatedPosts.map((post) => (
+              <Link
+                key={post.slug}
+                href={`/post/${post.slug}`}
+                className="group block rounded-lg border border-gray-200 px-4 py-3 hover:border-indigo-300 hover:bg-indigo-50 transition-colors duration-200"
+              >
+                <p className="text-sm text-gray-700 group-hover:text-indigo-700 leading-snug transition-colors duration-200">
+                  {post.meta.title}
+                </p>
+                <time className="text-xs text-gray-400 mt-1 block" dateTime={post.meta.date}>
+                  {post.meta.date}
+                </time>
+              </Link>
+            ))}
+          </div>
+        </section>
       )}
     </div>
   );

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { BlogTags } from "@/components/BlogTags";
 import { SpeakerdeckEmbed } from "@/components/SpeakerdeckEmbed/inedx";
 import { getPostMetadata, getSinglePostMetadata } from "@/getPostMetadata";
 import { getPostDescription } from "@/seo";
-import Image from "next/image";
+import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { monokaiSublime } from "react-syntax-highlighter/dist/esm/styles/hljs";
@@ -129,6 +129,11 @@ export default function Page({
   const resolvedParams = use(params);
   const { content, frontMatter } = getSinglePostMetadata(resolvedParams.slug);
 
+  const allPosts = getPostMetadata();
+  const currentIndex = allPosts.findIndex((p) => p.slug === resolvedParams.slug);
+  const newerPost = currentIndex > 0 ? allPosts[currentIndex - 1] : null;
+  const olderPost = currentIndex < allPosts.length - 1 ? allPosts[currentIndex + 1] : null;
+
   return (
     <div className="">
       <article>
@@ -167,6 +172,39 @@ export default function Page({
           />
         </div>
       </article>
+
+      {(newerPost || olderPost) && (
+        <nav className="mt-12 pt-8 border-t border-gray-200">
+          <div className="grid grid-cols-2 gap-4">
+            {olderPost ? (
+              <Link
+                href={`/post/${olderPost.slug}`}
+                className="group rounded-lg border border-gray-200 px-4 py-3 hover:border-indigo-300 hover:bg-indigo-50 transition-colors duration-200"
+              >
+                <span className="text-xs text-gray-400">← 前の記事</span>
+                <p className="text-sm text-gray-700 group-hover:text-indigo-700 mt-1 leading-snug transition-colors duration-200">
+                  {olderPost.meta.title}
+                </p>
+              </Link>
+            ) : (
+              <div />
+            )}
+            {newerPost ? (
+              <Link
+                href={`/post/${newerPost.slug}`}
+                className="group rounded-lg border border-gray-200 px-4 py-3 hover:border-indigo-300 hover:bg-indigo-50 transition-colors duration-200 text-right"
+              >
+                <span className="text-xs text-gray-400">次の記事 →</span>
+                <p className="text-sm text-gray-700 group-hover:text-indigo-700 mt-1 leading-snug transition-colors duration-200">
+                  {newerPost.meta.title}
+                </p>
+              </Link>
+            ) : (
+              <div />
+            )}
+          </div>
+        </nav>
+      )}
     </div>
   );
 }

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,0 +1,18 @@
+import { FaGithub } from "react-icons/fa";
+
+export const Footer = () => {
+  return (
+    <footer className="border-t border-gray-200 py-6 px-4 text-center text-xs text-gray-400">
+      <div className="flex items-center justify-center gap-4">
+        <span>&copy; {new Date().getFullYear()} tk1024.net</span>
+        <a
+          href="https://github.com/tk1024/tk1024.net"
+          className="inline-flex items-center gap-1 text-gray-400 hover:text-indigo-600 transition-colors duration-200"
+        >
+          <FaGithub />
+          <span>Source</span>
+        </a>
+      </div>
+    </footer>
+  );
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,10 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
-import { FaGithub } from "react-icons/fa";
-import { FaTwitter } from "react-icons/fa";
-import { FaTumblr } from "react-icons/fa";
+import { FaGithub, FaTwitter, FaTumblr } from "react-icons/fa";
 import { SiQiita } from "react-icons/si";
-import { TiHome } from "react-icons/ti";
 
 const socials = [
   {
@@ -31,47 +28,28 @@ const socials = [
 
 export const Header = () => {
   return (
-    <header className="text-white my-7">
-      <Link href="/">
-        <h1 className="text-2xl text-center font-bold">tk1024.net</h1>
-      </Link>
-      <div className="w-full flex items-center justify-center mt-7 mb-5">
-        <div className="rounded-full overflow-hidden lg:w-36 w-24">
-          <Image alt="" width={248} height={248} src={"/icon.jpg"} />
+    <header className="bg-indigo-700 text-white">
+      <div className="max-w-4xl mx-auto px-4 lg:px-10 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="rounded-full overflow-hidden w-10 h-10 flex-shrink-0">
+            <Image alt="" width={248} height={248} src={"/icon.jpg"} />
+          </div>
+          <Link href="/" className="text-xl font-bold hover:opacity-80 transition-opacity">
+            tk1024.net
+          </Link>
         </div>
-      </div>
-      <ul className="grid grid-cols-4 mx-12">
-        {socials.map((s) => (
-          <li key={s.name} className="flex justify-center">
+        <nav className="flex items-center gap-3">
+          {socials.map((s) => (
             <a
+              key={s.name}
               href={s.link}
               title={s.name}
-              className="w-8 h-8 bg-white rounded-full flex justify-center items-center"
+              className="w-8 h-8 bg-white rounded-full flex justify-center items-center hover:opacity-80 transition-opacity"
             >
-              <s.icon
-                size={"1.2rem"}
-                color="rgb(67 56 202 / var(--tw-bg-opacity))"
-              />
+              <s.icon size={"1rem"} color="rgb(67 56 202)" />
             </a>
-          </li>
-        ))}
-      </ul>
-      <div className="text-xs my-7 px-10 text-center">
-        <p className="mb-1">メモとSNSリンクが載っています</p>
-        <a
-          href="https://github.com/tk1024/tk1024.net"
-          className="flex justify-center items-center my-2"
-        >
-          <FaGithub className="mr-2" /> tk1024 / tk1024.net
-        </a>
-      </div>
-      <div className="my-8 px-4">
-        <hr className="border-indigo-500" />
-      </div>
-      <div className="ml-5">
-        <Link href="/" className="flex items-center my-4">
-          <TiHome className="mr-2" /> Home
-        </Link>
+          ))}
+        </nav>
       </div>
     </header>
   );


### PR DESCRIPTION
## 概要
- 記事ページに前後の記事へのナビゲーション（← 前の記事 / 次の記事 →）を追加
- タグベースの関連記事セクションを追加（最大3件）
- グローバル footer を追加（コピーライト + GitHub リンク）
- サイドバーレイアウトを廃止し、グローバルヘッダー + 縦積みレイアウトに変更

## テスト計画
- [ ] トップページの表示確認
- [ ] 記事ページで前後ナビゲーションが正しく表示されること
- [ ] 最初・最後の記事で片方のナビのみ表示されること
- [ ] 関連記事がタグ一致順で表示されること
- [ ] ヘッダー・フッターが全ページで表示されること
- [ ] モバイル表示の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)