### PR TITLE
feat(seo): robots.txt・JSON-LD構造化データ・パンくずリストを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getPostMetadata } from "@/getPostMetadata";
 import { PostList } from "@/components/PostList";
+import { WebSiteJsonLd } from "@/components/JsonLd";
 
 export const metadata: Metadata = {
   title: "TypeScript・React・Next.js の技術ブログ",
@@ -13,6 +14,7 @@ export default function Home() {
 
   return (
     <div className="animate-fade-in">
+      <WebSiteJsonLd />
       {/* Hero / Introduction */}
       <section className="mb-14">
         <h1 className="font-serif text-4xl lg:text-5xl tracking-tight text-ink leading-tight">

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -157,7 +157,7 @@ export default function Page({
   const description = getPostDescription(frontMatter.description, content);
 
   return (
-    <div className="animate-fade-in">
+    <div className="animate-fade-in -mt-8">
       <BlogPostingJsonLd
         title={frontMatter.title}
         description={description}

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { AiBadge } from "@/components/AiBadge";
 import { BlogTags } from "@/components/BlogTags";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { BlogPostingJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import { SpeakerdeckEmbed } from "@/components/SpeakerdeckEmbed/inedx";
 import { getPostMetadata, getSinglePostMetadata } from "@/getPostMetadata";
 import { getPostDescription } from "@/seo";
@@ -152,8 +154,32 @@ export default function Page({
         .slice(0, 3)
     : [];
 
+  const description = getPostDescription(frontMatter.description, content);
+
   return (
     <div className="animate-fade-in">
+      <BlogPostingJsonLd
+        title={frontMatter.title}
+        description={description}
+        date={frontMatter.date}
+        slug={resolvedParams.slug}
+        author={frontMatter.author}
+        tags={frontMatter.tags}
+      />
+      <BreadcrumbJsonLd
+        items={[
+          { name: "ホーム", href: "/" },
+          { name: "記事一覧", href: "/post" },
+          { name: frontMatter.title, href: `/post/${resolvedParams.slug}` },
+        ]}
+      />
+      <Breadcrumb
+        items={[
+          { name: "ホーム", href: "/" },
+          { name: "記事一覧", href: "/post" },
+          { name: frontMatter.title, href: `/post/${resolvedParams.slug}` },
+        ]}
+      />
       <article>
         {/* Article header */}
         <header className="mb-10 pb-8 border-b border-cream-300">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export function Breadcrumb({
+  items,
+}: {
+  items: { name: string; href: string }[];
+}) {
+  return (
+    <nav aria-label="パンくずリスト" className="mb-6 text-sm text-ink-faint">
+      <ol className="flex items-center gap-1.5 flex-wrap">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <li key={item.href} className="flex items-center gap-1.5">
+              {index > 0 && (
+                <span aria-hidden="true" className="text-cream-400">
+                  /
+                </span>
+              )}
+              {isLast ? (
+                <span className="text-ink-light truncate max-w-[20rem]">
+                  {item.name}
+                </span>
+              ) : (
+                <Link
+                  href={item.href}
+                  className="hover:text-forest transition-colors duration-200"
+                >
+                  {item.name}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -6,19 +6,19 @@ export function Breadcrumb({
   items: { name: string; href: string }[];
 }) {
   return (
-    <nav aria-label="パンくずリスト" className="mb-6 text-sm text-ink-faint">
-      <ol className="flex items-center gap-1.5 flex-wrap">
+    <nav aria-label="パンくずリスト" className="mb-8 text-xs text-ink-faint tracking-wide">
+      <ol className="flex items-center gap-1 flex-wrap">
         {items.map((item, index) => {
           const isLast = index === items.length - 1;
           return (
-            <li key={item.href} className="flex items-center gap-1.5">
+            <li key={item.href} className="flex items-center gap-1">
               {index > 0 && (
-                <span aria-hidden="true" className="text-cream-400">
-                  /
+                <span aria-hidden="true" className="text-cream-400 select-none">
+                  ›
                 </span>
               )}
               {isLast ? (
-                <span className="text-ink-light truncate max-w-[20rem]">
+                <span className="text-ink-light truncate max-w-[18rem]">
                   {item.name}
                 </span>
               ) : (

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,86 @@
+import { siteUrl } from "@/site";
+import { siteMetadata } from "@/seo";
+
+export function WebSiteJsonLd() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: siteMetadata.siteName,
+    url: siteUrl,
+    description: siteMetadata.defaultDescription,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}
+
+export function BreadcrumbJsonLd({
+  items,
+}: {
+  items: { name: string; href: string }[];
+}) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: `${siteUrl}${item.href}`,
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}
+
+export function BlogPostingJsonLd({
+  title,
+  description,
+  date,
+  slug,
+  author,
+  tags,
+}: {
+  title: string;
+  description: string;
+  date: string;
+  slug: string;
+  author?: string;
+  tags?: string[];
+}) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: title,
+    description,
+    datePublished: date,
+    url: `${siteUrl}/post/${slug}`,
+    image: `${siteUrl}/post/${slug}/opengraph-image`,
+    author: {
+      "@type": "Person",
+      name: author ?? "tk1024",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: siteMetadata.siteName,
+      url: siteUrl,
+    },
+    ...(tags && tags.length > 0 ? { keywords: tags.join(", ") } : {}),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- `robots.ts` を追加し、クローラールールとサイトマップURLを明示的に定義
- JSON-LD 構造化データ（WebSite / BlogPosting / BreadcrumbList）を各ページに追加し、リッチリザルト対応を強化
- 記事ページにパンくずリストUIを追加し、サイト内ナビゲーションを改善

## 変更ファイル
### 新規
- `src/app/robots.ts` — robots.txt 生成
- `src/components/JsonLd.tsx` — JSON-LD コンポーネント（3種）
- `src/components/Breadcrumb.tsx` — パンくずリストUI

### 変更
- `src/app/page.tsx` — WebSite JSON-LD を追加
- `src/app/post/[slug]/page.tsx` — BlogPosting / BreadcrumbList JSON-LD + パンくずUI を追加

## Test plan
- [ ] `next build` が成功することを確認
- [ ] トップページのHTMLに `WebSite` JSON-LD が出力されることを確認
- [ ] 記事ページのHTMLに `BlogPosting` / `BreadcrumbList` JSON-LD が出力されることを確認
- [ ] 記事ページにパンくずリストが表示されることを確認
- [ ] [Rich Results Test](https://search.google.com/test/rich-results) で構造化データが正しく認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)